### PR TITLE
Fix Release builds using SPM

### DIFF
--- a/AmazonChimeSDK/AmazonChimeSDK.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/AmazonChimeSDK/AmazonChimeSDK.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,16 +1,14 @@
 {
-  "object": {
-    "pins": [
-      {
-        "package": "Mockingbird",
-        "repositoryURL": "https://github.com/birdrides/mockingbird",
-        "state": {
-          "branch": null,
-          "revision": "50feb5e24587091abfc5c37b2dc9be7c1bbdd7f0",
-          "version": "0.15.0"
-        }
+  "pins" : [
+    {
+      "identity" : "mockingbird",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/birdrides/mockingbird",
+      "state" : {
+        "revision" : "50feb5e24587091abfc5c37b2dc9be7c1bbdd7f0",
+        "version" : "0.15.0"
       }
-    ]
-  },
-  "version": 1
+    }
+  ],
+  "version" : 2
 }

--- a/AmazonChimeSDK/AmazonChimeSDK/internal/utils/ConcurrentMutableSet.swift
+++ b/AmazonChimeSDK/AmazonChimeSDK/internal/utils/ConcurrentMutableSet.swift
@@ -8,7 +8,7 @@
 
 import Foundation
 
-@objcMembers class ConcurrentMutableSet {
+class ConcurrentMutableSet {
     private let lock = NSRecursiveLock()
     private let set = NSMutableSet()
     var count: Int {

--- a/Package.swift
+++ b/Package.swift
@@ -34,8 +34,7 @@ let package = Package(
             name: "AmazonChimeSDK",
             dependencies: [.targetItem(name: "AmazonChimeSDKMedia", condition: nil)],
             path: "AmazonChimeSDK/AmazonChimeSDK",
-            exclude: ["audiovideo/video/backgroundfilter/TensorFlowSegmentationProcessor.m"]//,
-//            publicHeadersPath: "AmazonChimeSDK.h"
+            exclude: ["audiovideo/video/backgroundfilter/TensorFlowSegmentationProcessor.m"]
         ),
         .testTarget(
             name: "AmazonChimeSDKTests",

--- a/Package.swift
+++ b/Package.swift
@@ -32,9 +32,10 @@ let package = Package(
         // Targets can depend on other targets in this package and products from dependencies.
         .target(
             name: "AmazonChimeSDK",
-            path: "AmazonChimeSDK/AmazonChimeSDK",
-            exclude: ["audiovideo/video/backgroundfilter/TensorFlowSegmentationProcessor.m"],
-            publicHeadersPath: "AmazonChimeSDK.h"
+            dependencies: [.targetItem(name: "AmazonChimeSDKMedia", condition: nil)],
+            path: "AmazonChimeSDK/AmazonChimeSDK"//,
+//            exclude: ["audiovideo/video/backgroundfilter/TensorFlowSegmentationProcessor.m"]//,
+//            publicHeadersPath: "AmazonChimeSDK.h"
         ),
         .testTarget(
             name: "AmazonChimeSDKTests",

--- a/Package.swift
+++ b/Package.swift
@@ -33,8 +33,8 @@ let package = Package(
         .target(
             name: "AmazonChimeSDK",
             dependencies: [.targetItem(name: "AmazonChimeSDKMedia", condition: nil)],
-            path: "AmazonChimeSDK/AmazonChimeSDK"//,
-//            exclude: ["audiovideo/video/backgroundfilter/TensorFlowSegmentationProcessor.m"]//,
+            path: "AmazonChimeSDK/AmazonChimeSDK",
+            exclude: ["audiovideo/video/backgroundfilter/TensorFlowSegmentationProcessor.m"]//,
 //            publicHeadersPath: "AmazonChimeSDK.h"
         ),
         .testTarget(

--- a/script to build framework.txt
+++ b/script to build framework.txt
@@ -1,4 +1,0 @@
-
-xcodebuild archive -project AmazonChimeSDK/AmazonChimeSDK.xcodeproj -configuration Release -scheme AmazonChimeSDK -destination "generic/platform=iOS" -archivePath "~/Desktop/AmazonChimeSDK" SKIP_INSTALL=NO BUILD_LIBRARY_FOR_DISTRIBUTION=YES
-xcodebuild archive -project AmazonChimeSDK/AmazonChimeSDK.xcodeproj -configuration Release -scheme AmazonChimeSDK -destination "generic/platform=iOS Simulator" -archivePath "~/Desktop/AmazonChimeSDK Sim" SKIP_INSTALL=NO BUILD_LIBRARY_FOR_DISTRIBUTION=YES
-xcodebuild -create-xcframework -framework ~/Desktop/AmazonChimeSDK.xcarchive/Products/Library/Frameworks/AmazonChimeSDK.framework -framework ~/Desktop/AmazonChimeSDK\ Sim.xcarchive/Products/Library/Frameworks/AmazonChimeSDK.framework -output ~/Desktop/AmazonChimeSDK.xcframework

--- a/script to build framework.txt
+++ b/script to build framework.txt
@@ -1,0 +1,4 @@
+
+xcodebuild archive -project AmazonChimeSDK/AmazonChimeSDK.xcodeproj -configuration Release -scheme AmazonChimeSDK -destination "generic/platform=iOS" -archivePath "~/Desktop/AmazonChimeSDK" SKIP_INSTALL=NO BUILD_LIBRARY_FOR_DISTRIBUTION=YES
+xcodebuild archive -project AmazonChimeSDK/AmazonChimeSDK.xcodeproj -configuration Release -scheme AmazonChimeSDK -destination "generic/platform=iOS Simulator" -archivePath "~/Desktop/AmazonChimeSDK Sim" SKIP_INSTALL=NO BUILD_LIBRARY_FOR_DISTRIBUTION=YES
+xcodebuild -create-xcframework -framework ~/Desktop/AmazonChimeSDK.xcarchive/Products/Library/Frameworks/AmazonChimeSDK.framework -framework ~/Desktop/AmazonChimeSDK\ Sim.xcarchive/Products/Library/Frameworks/AmazonChimeSDK.framework -output ~/Desktop/AmazonChimeSDK.xcframework


### PR DESCRIPTION
The issue seems to have been that when building for Release, some optimizations caused issues with ConcurrentMutableSet.

The exception was thrown while calling `lock.lock()`. Since `lock` was being called on `__SharedStringStorage`, it seemed that optimizations were causing the `lock` instance to not really point to the `NSRecursiveLock` anymore. Removing `@objcMembers` fixed the issue.

```
*** Terminating app due to uncaught exception 'NSInvalidArgumentException', reason: '-[Swift.__SharedStringStorage lock]: unrecognized selector sent to instance 0x2803f4c30'
```



- Working on local package from source again
- Build 27
- Fixed build issue
- Clean up
